### PR TITLE
Adding missing default currency

### DIFF
--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -23,6 +23,9 @@ return [
 
     // Snipcart secret API key
     'secretApiKey' => '',
+    
+    // default currency
+    'defaultCurrency' => 'USD',    
 
     // send order notifications to designated store admins
     'sendOrderNotificationEmail' => false,


### PR DESCRIPTION
This adds the defaultCurrency key/value to the default static config example.